### PR TITLE
Remove dot from end of url in config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -45,7 +45,7 @@ docusaurus:
       - Template-chapter: /build/make_assets/content/chapters/template-chapter/lecture/_site
     config_meta:
       title: Template Repo
-      url: gabrielaciuprina.github.io.
+      url: gabrielaciuprina.github.io
       baseUrl: /ElectricalEngineering/
       onBrokenLinks: warn
       onBrokenMarkdownLinks: warn


### PR DESCRIPTION
The `.` at the end made the build fail.